### PR TITLE
fix crash from legacy route ids

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -2,7 +2,7 @@ module.exports = {
   expo: {
     name: 'Ames Ride',
     slug: 'AmesRide',
-    version: '1.2.0',
+    version: '1.2.1',
     sdkVersion: '47.0.0',
     orientation: 'portrait',
     icon: './assets/icon.png',
@@ -37,7 +37,6 @@ module.exports = {
       },
       package: 'com.demerstech.amesride',
     },
-    jsEngine: 'hermes',
     web: {
       favicon: './assets/favicon.png',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ames-ride",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ames-ride",
-      "version": "1.1.1",
+      "version": "1.2.1",
       "license": "GNU3",
       "dependencies": {
         "@aveq-research/localforage-asyncstorage-driver": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ames-ride",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "GNU3",
   "scripts": {
     "start": "expo start",

--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -54,6 +54,8 @@ export const favoriteRoutesOnlyState = selector({
 
     const favorites = [];
     favoriteRouteIds.forEach((routeId) => {
+      // routeId used to be a number. ignore these
+      if (typeof routeId !== 'string' || !data.routes[routeId]) return;
       favorites.push(data.routes[routeId]);
     });
 


### PR DESCRIPTION
Route IDs used to be stored as numbers but are now strings. Ignore any numbers in user's list of favorite routes.

This fixes the issue of app crashing on load. Closes #74.